### PR TITLE
fix: no longer hardcode the user name

### DIFF
--- a/PaintDotNetTemplateEffect2023.csproj
+++ b/PaintDotNetTemplateEffect2023.csproj
@@ -58,7 +58,7 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy &quot;$(TargetPath)&quot; &quot;C:\Users\Andrew\Documents\paint.net App Files\Effects\Testing&quot;" />
-  </Target>
+<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy &quot;$(TargetPath)&quot; &quot;$(ProjectDir)bin\$(Configuration)\$(TargetFileName)&quot;" />
+</Target>
 </Project>


### PR DESCRIPTION
I've noticed a relatively huge issue in the `csproj` file. It expects the username of the Windows user to "Andrew". That's simply not the case for a lot of people. I've made a correction and am having the output be directed towards the project's bin folder. 

If you still want the output file to head to that destination, I can set it to output to the same location. Though this time use the username variable. 